### PR TITLE
Typo in sample config, and can't read port number

### DIFF
--- a/conf/config.json.sample
+++ b/conf/config.json.sample
@@ -12,7 +12,7 @@
     "filters" : [
         {
             "host": "netflix.com",
-            "query": "AAAA",
+            "type": "AAAA",
             "matching": "contains"
         }
     ]

--- a/config.go
+++ b/config.go
@@ -99,14 +99,14 @@ func parseConfigFile(configPath string) (*DNSConfig, error) {
 
 	config.Host = host
 
-	port, portExists := configMap["port"].(int64)
+	port, portExists := configMap["port"].(float64)
 
 	if !portExists {
 		// bind to port 1234 by default
 		port = 1234
 	}
 
-	config.Port = port
+	config.Port = int64(port)
 
 	forwardingSlice, forwardingMapExists := configMap["forwarders"].([]interface{})
 


### PR DESCRIPTION
Thanks for creating this program; I'm glad to be able to use Netflix again!

Two small things: first, it looks like the correct config syntax uses "type", not "query"; the sample config gets it wrong.

Second, the code to read the port number was apparently not working.  encoding/json (like Javascript) uses a float64 representation for all numbers.  I don't know Go, but I hope the attached patch is the right way to fix it.

I hope you don't mind me putting two issues in one PR; I can split them if you prefer.
