### PR TITLE
Log to standard out when no logfile provided

### DIFF
--- a/log.go
+++ b/log.go
@@ -67,7 +67,7 @@ func setupLogging(logFilePath string) {
 
 		logger = log.New(fo, "", log.LstdFlags)
 	} else {
-		panic("Missing logfile")
+		logger = log.New(os.Stdout, "", log.LstdFlags)
 	}
 }
 


### PR DESCRIPTION
I think logging to standard out is a better behaviour than `panic`ing when no log file is configured.

Signed-off-by: Dave Henderson dhenderson@gmail.com
